### PR TITLE
Add PDF export

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, session, jsonify, request, Response
 from flask_cors import CORS
 from drive import drive_bp  # You can keep this if you want to retry Drive later
+from fpdf import FPDF
 import os
 import json
 import csv
@@ -85,6 +86,42 @@ def download_csv():
         csv_string,
         mimetype="text/csv",
         headers={"Content-Disposition": "attachment;filename=firearms.csv"}
+    )
+
+
+# ----- PDF Export -----
+@app.route('/download/pdf', methods=['GET'])
+def download_pdf():
+    data = load_data()
+
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+
+    pdf.cell(0, 10, txt="Firearm Inventory", ln=True, align='C')
+    pdf.ln(10)
+
+    headers = ['Name', 'Serial Number', 'Purchase Price', 'Current Value', 'Purchase Date', 'Notes']
+    col_width = 30
+    for header in headers:
+        pdf.cell(col_width, 10, txt=header, border=1)
+    pdf.ln()
+
+    for firearm in data:
+        pdf.cell(col_width, 10, txt=str(firearm.get('name', '')), border=1)
+        pdf.cell(col_width, 10, txt=str(firearm.get('serial_number', '')), border=1)
+        pdf.cell(col_width, 10, txt=str(firearm.get('purchase_price', '')), border=1)
+        pdf.cell(col_width, 10, txt=str(firearm.get('current_value', '')), border=1)
+        pdf.cell(col_width, 10, txt=str(firearm.get('purchase_date', '')), border=1)
+        pdf.cell(col_width, 10, txt=str(firearm.get('notes', '')), border=1)
+        pdf.ln()
+
+    pdf_output = pdf.output(dest='S').encode('latin-1')
+
+    return Response(
+        pdf_output,
+        mimetype="application/pdf",
+        headers={"Content-Disposition": "attachment;filename=firearms.pdf"}
     )
 
 

--- a/index.html
+++ b/index.html
@@ -50,7 +50,8 @@
 
     <!-- Action Buttons -->
     <div class="mb-3">
-      <button class="btn btn-outline-info" onclick="downloadCSV()">📥 Export as CSV</button>
+      <button class="btn btn-outline-info me-2" onclick="downloadCSV()">📥 Export as CSV</button>
+      <button class="btn btn-outline-info" onclick="downloadPDF()">📄 Export as PDF</button>
     </div>
 <div class="card mb-4">
   <div class="card-body">
@@ -228,6 +229,10 @@
   // Download CSV
   function downloadCSV() {
     window.location.href = 'http://127.0.0.1:5000/download/csv';
+  }
+
+  function downloadPDF() {
+    window.location.href = 'http://127.0.0.1:5000/download/pdf';
   }
 
   // Initial load


### PR DESCRIPTION
## Summary
- add PDF export route using FPDF
- support PDF button on the frontend

## Testing
- `python -m py_compile app.py drive.py`
- `curl -I http://127.0.0.1:5000/download/pdf`

------
https://chatgpt.com/codex/tasks/task_e_687fd4cb151c832ab1ba12ebcf15f5c9